### PR TITLE
Remove JCommander vulnerability to WS-2019-0490

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,12 +79,12 @@
             <dependency>
                 <groupId>com.beust</groupId>
                 <artifactId>jcommander</artifactId>
-                <version>1.72</version>
+                <version>1.78</version>
             </dependency>
             <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
-                <version>6.14.3</version>
+                <version>7.3.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Because JCommander 1.72 is vulnerable to WS-2019-0490, it should be uudated to 1.78, 
Because TestNG also uses JCommander, it should be upgraded to 7.3.0